### PR TITLE
Remove version from composer.json for using tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "reilag/php-anticaptcha",
-    "version": "1.2.4",
     "type": "library",
     "description": "AntiCaptcha - Is PHP Library for working with Anticapthca services",
     "keywords": ["php", "anticaptcha", "anti-captcha", "antigate", "rucaptcha"],


### PR DESCRIPTION
Composer uses git tags for the resolving version. Duplicate version in the composer.json file is not required.